### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,4 +1,6 @@
 name: precommit-action
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   linter_name:


### PR DESCRIPTION
Potential fix for [https://github.com/hud-turn/netops-git-push-only/security/code-scanning/2](https://github.com/hud-turn/netops-git-push-only/security/code-scanning/2)

To fix the problem, you should explicitly set a `permissions` key for the workflow or the relevant job. Since the workflow contains only one job, you can add the following to the top-level (root) of the workflow (just under the `name`, before `on` or `jobs`), or inside the job itself as per context. The minimal recommended permissions for running linters/pre-commit checks is typically `contents: read`, unless workflow steps clearly require additional privileges (such as commenting on PRs or adding annotations—here, no such write actions are seen). Therefore, add the following block:

```yaml
permissions:
  contents: read
```

to the top level of `.github/workflows/precommit.yml` (after the `name:` line and before the `on:` line).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
